### PR TITLE
encode outgoing query string in Service.request (needed for using query syntax on routes).

### DIFF
--- a/api/policies/validJSONRequest.js
+++ b/api/policies/validJSONRequest.js
@@ -14,7 +14,7 @@ module.exports = function validJSONRequest (req, res, next) {
     var requestContentType = contentType.parse(req);
 
     if (requestContentType.parameters['charset']) {
-        if (requestContentType.parameters.charset != 'UTF-8') {
+        if (requestContentType.parameters.charset.toLowerCase() != 'utf-8') {
             return res.unsupportedMediaType({
                 name: 'Unsupported Character Encoding',
                 mesasge: "'" + requestContentType.parameters.charset + "' is an usupported character encoding.",

--- a/api/responses/serverError.js
+++ b/api/responses/serverError.js
@@ -10,7 +10,7 @@ var ServiceError = require('../services/errors/ServiceError.js');
 
 module.exports = function (errors) {
     var response = new Response(this.req, this.res, 500);
-    if (errors && !(errors instanceof ServiceError)) {
+    if (errors && (!(errors instanceof ServiceError) && !(errors instanceof Error))) {
         errors = new ServiceError(errors);
     }
     response.addErrors(errors);

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -64,12 +64,12 @@ function loadSeedData(options) {
 }
 
 
-function mockService(serviceName){
-    if(mocks.hasOwnProperty(serviceName)){
-        mocks[serviceName]();
+function mockService(requestedService){
+    if(mocks.hasOwnProperty(requestedService)){
+        mocks[requestedService]();
         return {
             id: "someRandomId",
-            host: serviceName,
+            host: requestedService,
             port: 80,
         }
     } else {
@@ -123,10 +123,10 @@ function getDiscoveryInfo(nodeName, info) {
     return result;
 }
 
-function getRandomService(serviceName) {
+function getRandomService(requestedService) {
     //this will either return a random node from the nodes list that corresponds
-    //to the serviceName provided, or will return null if no service matching the
-    //serviceName was found in the nodes list
+    //to the requestedService provided, or will return null if no service matching the
+    //requestedService was found in the nodes list
     //todo: I'm thinking that it might be useful to prefer a service that is running on the
     //      same host where the request is coming from, but this might only be useful when
     //      working on a development machine where all services are running locally.  This
@@ -136,10 +136,10 @@ function getRandomService(serviceName) {
     // (can't cache these because the list of services can change at any time)
     var serviceList = _.reduce(nodes, function (list, host, hostName) {
         _.each(host, function (service, name) {
-            if (name == serviceName) {
+            if (name == requestedService) {
                 _.each(service, function (item, id) {
                     if (item.hasOwnProperty('status')) {
-                        if (item.status == 'running') {
+                        if (item.status == 'online') {
                             list.push(item);
                         }
                     }
@@ -152,26 +152,26 @@ function getRandomService(serviceName) {
         result = _.sample(serviceList);
     }
     else if (process.env.USE_MOCKS) {
-        result = mockService(serviceName)
+        result = mockService(requestedService)
     }
     return result;
 }
 
-var serviceCall = function(serviceName) {
-    var service = getRandomService(serviceName);
+var serviceCall = function(requestedService) {
+    var service = getRandomService(requestedService);
 
     var serviceNotAvailable = function (error) {
         //todo: send some kind of notification that the service is not available
         //we don't need to mark the service as unavailable in the discovery node list because
         //if it is 'really' unavailable, the auto-discovery mechanism will know and will remove
         //it from the discovery list.
-        serviceError = new ServiceError(serviceName, 'Service is unavailable', error);
+        serviceError = new ServiceError(requestedService, 'Service is unavailable', error);
         return Promise.reject(serviceError);
     }
     return {
         get   : function (path) {
             if (service) {
-                sails.config.metrics.serviceCallCounter.increment({ service: serviceName, method: 'GET', url: path });
+                sails.config.metrics.serviceCallCounter.increment({ service: requestedService, method: 'GET', url: path });
                 return request({
                     method: 'GET',
                     host  : service.host,
@@ -188,7 +188,7 @@ var serviceCall = function(serviceName) {
         },
         put   : function (path, data) {
             if (service) {
-                sails.config.metrics.serviceCallCounter.increment({ service: serviceName, method: 'PUT', url: path });
+                sails.config.metrics.serviceCallCounter.increment({ service: requestedService, method: 'PUT', url: path });
                 return request({
                     method: 'PUT',
                     host  : service.host,
@@ -206,7 +206,7 @@ var serviceCall = function(serviceName) {
         },
         post  : function (path, data) {
             if (service) {
-                sails.config.metrics.serviceCallCounter.increment({ service: serviceName, method: 'POST', url: path });
+                sails.config.metrics.serviceCallCounter.increment({ service: requestedService, method: 'POST', url: path });
                 return request({
                     method: 'POST',
                     host  : service.host,
@@ -224,7 +224,7 @@ var serviceCall = function(serviceName) {
         },
         delete: function (path) {
             if (service) {
-                sails.config.metrics.serviceCallCounter.increment({ service: serviceName, method: 'DELETE', url: path });
+                sails.config.metrics.serviceCallCounter.increment({ service: requestedService, method: 'DELETE', url: path });
                 return request({
                     method: 'DELETE',
                     host  : service.host,
@@ -378,9 +378,10 @@ Discovery.prototype.register = function (serviceOptions) {
 
             var info = {
                 id     : obj.id,
-                host   : obj.advertisement.loadbalancer || obj.hostName,
+                host   : obj.advertisement.loadBalancer || obj.hostName,
                 address: obj.address,
                 type   : type,
+                status : 'online'
             }
             if (!obj.advertisement.loadBalancer) {
                 info.port = obj.advertisement.port;
@@ -396,9 +397,9 @@ Discovery.prototype.register = function (serviceOptions) {
                     path   : '/info'
                 }).then(function (result) {
                     sails.config.metrics.serviceCallCounter.increment({service: name, method: 'GET', url: '/info'});
-                    if (result.body) {
-                        if (result.body.hasOwnProperty('routes')) {
-                            info.routes = result.body.routes;
+                    if (result) {
+                        if (result.hasOwnProperty('routes')) {
+                            info.routes = result.routes;
                         }
                         else {
                             //todo: send a notification that the newly added service hasn't exposed any routes to auto-discovery
@@ -406,11 +407,10 @@ Discovery.prototype.register = function (serviceOptions) {
                             info.routes = 'unavailable';
                         }
                     }
-                    return 'running';
+                    return info;
                 })
-                : Promise.resolve('running'))
-            .then(function(status) {
-                info.status = status;
+                : Promise.resolve(info))
+            .then(function(info) {
                 return (addDiscoveryInfo(name, info))
             }).catch(function (error) {
                 //the service isn't accepting REST requests for some reason
@@ -472,12 +472,12 @@ Discovery.prototype.register = function (serviceOptions) {
 
 Discovery.prototype.request = serviceCall;
 
-Discovery.prototype.addMock = function (serviceName, mockDefinition) {
+Discovery.prototype.addMock = function (requestedService, mockDefinition) {
     //ensure that we can only call this if the environment variable USE_MOCKS has been set to 'true'
     if (!process.env.USE_MOCKS) {
         throw new Error('Unable to add mock definition unless environment variable "USE_MOCKS" has been set to "true"');
     }
-    mocks[serviceName] = mockDefinition;
+    mocks[requestedService] = mockDefinition;
 }
 
 Discovery.prototype.getName = function () {

--- a/lib/errors/ServiceError.js
+++ b/lib/errors/ServiceError.js
@@ -10,7 +10,13 @@ function ServiceError(serviceName, message, error) {
 
     this.name = serviceName;
 
+    if (message instanceof Error) {
+        error = message;
+        message = error.message;
+    }
+
     if ((typeof message != 'string') &&  !(message instanceof String)) {
+
         if ((error instanceof Error)) {
             this.error = error;
         }

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,4 +1,5 @@
 var http = require('http');
+var queryString = require('querystring');
 var Promise = require('bluebird');
 var util = require('util');
 var url = require('url');
@@ -52,7 +53,6 @@ module.exports = function(options) {
 
         if (options.data) {
             data = options.data;
-            delete options.data;
         };
         if (options.service) {
             if (!options.hasOwnProperty('headers')) {
@@ -65,6 +65,13 @@ module.exports = function(options) {
         }
         if (options.timeout) {
             timeout = options.timeout;
+        }
+        if (options.path) {
+            var path = url.parse(options.path);
+            if (path.query) {
+                var queryData = queryString.parse(path.query);
+                options.path = path.pathname + '?' + queryString.stringify(queryData);
+            }
         }
         var request = http.request(options, function(response) {
             response.setEncoding('utf8');
@@ -92,8 +99,8 @@ module.exports = function(options) {
                     resolve(result.json);
                 }
                 else {
-                    var rejectError = new ServiceError(serviceName, result);
-                    reject(rejectError);
+                    //var rejectError = new ServiceError(serviceName, result);
+                    reject(result);
                 }
             });
         });
@@ -104,7 +111,7 @@ module.exports = function(options) {
                 reject(new ServiceError(serviceName, request.method + ' ' + request.url + ' timed out after ' + timeout + ' seconds.'));
             });
         }
-        // Handle errors (does this ever get called?)
+        // Handle errors
         request.on('error', function(error) {
             reject(new ServiceError(serviceName, error));
         });

--- a/lib/response.js
+++ b/lib/response.js
@@ -97,14 +97,14 @@ Response.prototype.addErrors = function(errors) {
     }
     else {
         if (errors && errors instanceof Error) {
-            errors.request = this.request;
-            errors.payload = this.payload;
+            errors.request = self.request;
+            errors.payload = self.payload;
             if (process.env.NODE_ENV != 'test') {
                 sails.log.error(util.inspect(errors, inspectOptions));
                 sails.log.error(errors.stack);
             }
-            delete errors.request;
-            delete errors.payload;
+            delete self.request;
+            delete self.payload;
 
             errors.name = errors.name;
             errors.message = errors.message;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "prometheus-client": "^0.1.0",
     "redis": "^0.12.1",
     "sails-build-dictionary": "^0.10.1",
+    "sails-disk": "^0.10.8",
     "sails-redis": "^0.10.3",
     "sails-util": "^0.10.4",
     "sails-util-mvcsloader": "^0.1.7"


### PR DESCRIPTION
if Service.request fails, return the failed response instead of wrapping it in a new error object - makes it much easier to determine failure reason from logs.
better error embedding in serverError response